### PR TITLE
fix(TimelineChart): get correct time on double tap [SO-2611712]

### DIFF
--- a/lib/timeline/TimelineChart.js
+++ b/lib/timeline/TimelineChart.js
@@ -104,7 +104,7 @@ class TimelineChart extends Core {
     });
     this.on('doubletap', function (event) {
       const eventProperties = me.getEventProperties(event);
-      eventProperties.snappedTime = this.body.util.toTime(event.changedPointers[0].offsetX - this.props.center.width);
+      eventProperties.snappedTime = this.body.util.toTime(event.changedPointers[0].offsetX);
       eventProperties.group = (this.pointToRow(event.changedPointers[0].offsetY) || {}).value;
       me.emit('doubleClick', eventProperties);
     });


### PR DESCRIPTION
### BEFORE
- PEPO
![Screen Recording 2021-09-01 at 19 36 25](https://user-images.githubusercontent.com/74916274/131754504-44ee53de-19f3-4694-a4c5-2cbf01a47d55.gif)

### AFTER
- PEPO
![Tab-1630534952513](https://user-images.githubusercontent.com/74916274/131753525-741b8204-134a-4c14-87f7-5481bc0975c1.gif)

- APAP
![Screen Recording 2021-09-01 at 19 30 47](https://user-images.githubusercontent.com/74916274/131754465-32da55c8-5dd2-41d3-a42f-36a5497385f9.gif)
