### PR TITLE
Configuração das Legendas “De Lee” e “Hodge”

### DIFF
--- a/lib/timeline/component/timeline-chart/DrawLabels.js
+++ b/lib/timeline/component/timeline-chart/DrawLabels.js
@@ -157,14 +157,34 @@ class DrawLabels {
    * @private
    */
   _renderCustomLabel({ lineHeight, orientation, labelClass, group }) {
-    const amountLabels = group.group.axisCustomLabel.length;
-    const intervalHeight = Math.floor(lineHeight / amountLabels);
+    const { length } = group.group.axisCustomLabel;
+    let amountLabels = length;
     let position = lineHeight - this.props.minorCharHeight;
-    group.group.axisCustomLabel.slice().reverse().forEach(axisCustomLabel => {
-      const customLabel = axisCustomLabel.alternativeLabel ? axisCustomLabel.alternativeLabel : axisCustomLabel.y;
-      this._redrawLabel(position, customLabel, orientation, labelClass, this.props.minorCharHeight);
-      position = position - intervalHeight;
-    })
+    const internHeight = lineHeight - this.props.minorCharHeight * 2;
+    const amountLabelsToFit = Math.floor(internHeight / this.props.minorCharHeight);
+
+    // Divides the number of labels to fit the available height
+    while (amountLabels > amountLabelsToFit) {
+      amountLabels = Math.floor((amountLabels - 2) / 2);
+    }
+    const intervalHeight = Math.floor(internHeight / amountLabels);
+
+    // Print top and bottom labels
+    const firstItem = group.group.axisCustomLabel[0];
+    const lastItem = group.group.axisCustomLabel[length - 1];
+    const lastItemLabel = lastItem.alternativeLabel ? lastItem.alternativeLabel : lastItem.y;
+    const firstItemLabel = firstItem.alternativeLabel ? firstItem.alternativeLabel : firstItem.y;
+    this._redrawLabel(position, lastItemLabel, orientation, labelClass, this.props.minorCharHeight);
+    this._redrawLabel(0, firstItemLabel, orientation, labelClass, this.props.minorCharHeight);
+
+    // Print middle labels
+    group.group.axisCustomLabel.slice().reverse()
+      .filter((a, i) => i > 0 && i % Math.floor(length / amountLabels) === 0)
+      .forEach(axisCustomLabel => {
+        position = position - intervalHeight;
+        const label = axisCustomLabel.alternativeLabel ? axisCustomLabel.alternativeLabel : axisCustomLabel.y;
+        this._redrawLabel(position, label, orientation, labelClass, this.props.minorCharHeight);
+    });
   }
 }
 

--- a/lib/timeline/component/timeline-chart/DrawLabels.js
+++ b/lib/timeline/component/timeline-chart/DrawLabels.js
@@ -43,6 +43,11 @@ class DrawLabels {
       return; // exit
     }
 
+    if (group.group.axisCustomLabel) {
+      this._renderCustomLabel({ lineHeight, orientation, labelClass, group });
+      return; // exit
+    }
+
     if (group.summary && group.group && group.group.intervalScale) {
       this._renderLabelWithScale({ lineHeight, orientation, labelClass, group, maxValue, minValue, avgValue, referenceLine });
       return; // exit
@@ -141,6 +146,25 @@ class DrawLabels {
       avgValue,
       referenceLine,
     };
+  }
+
+  /**
+   * Redraw axisCustomLabel list
+   * @param lineHeight
+   * @param orientation
+   * @param labelClass
+   * @param group
+   * @private
+   */
+  _renderCustomLabel({ lineHeight, orientation, labelClass, group }) {
+    const amountLabels = group.group.axisCustomLabel.length;
+    const intervalHeight = Math.floor(lineHeight / amountLabels);
+    let position = lineHeight - this.props.minorCharHeight;
+    group.group.axisCustomLabel.slice().reverse().forEach(axisCustomLabel => {
+      const customLabel = axisCustomLabel.alternativeLabel ? axisCustomLabel.alternativeLabel : axisCustomLabel.y;
+      this._redrawLabel(position, customLabel, orientation, labelClass, this.props.minorCharHeight);
+      position = position - intervalHeight;
+    })
   }
 }
 

--- a/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
+++ b/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
@@ -391,6 +391,7 @@ class TimelineChartLineGraph extends LineGraph {
         convertedValue = Math.round(baseScreenY * 50 / 100);
       } else {
         convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
+        convertedValue = this._convertNegativeScale({ group, range, convertedValue });
       }
       datapoints[i].screen_y = (actualY - (offset / 2)) - convertedValue;
     }
@@ -423,6 +424,7 @@ class TimelineChartLineGraph extends LineGraph {
         const minValue = datapoints[i].y;
         const difference = maxValue - minValue;
         convertedValue = Math.round(baseScreenY * 50 / 100);
+        convertedValue = this._convertNegativeScale({ group, range, convertedValue });
         if(datapoints[i].referenceLine){
           convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
         }
@@ -483,6 +485,31 @@ class TimelineChartLineGraph extends LineGraph {
     this.options.height = totalHeight + 1;
     this.options.graphHeight = totalHeight + 1;
     this.options.legend = { enabled: false }
+  }
+
+  /**
+   * IF max is less than min so the scale is inverted
+   * e.g -4 on top until 4 on bottom
+   * @param group
+   * @param range
+   * @param convertedValue
+   * @returns {number}
+   * @private
+   */
+  _convertNegativeScale({ group, range, convertedValue }) {
+    let first = range.max;
+    let last = range.min;
+    if (group?.group?.axisCustomLabel) {
+      const listOfYLabels = group.group.axisCustomLabel.map(d => d.y);
+      first = listOfYLabels[0];
+      last = listOfYLabels[listOfYLabels.length - 1];
+      range.max = Math.max(...listOfYLabels);
+      range.min = Math.min(...listOfYLabels);
+    }
+    if (first < last) {
+      convertedValue = baseScreenY - convertedValue;
+    }
+    return convertedValue;
   }
 }
 

--- a/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
+++ b/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
@@ -362,28 +362,13 @@ class TimelineChartLineGraph extends LineGraph {
 
   _convertPointsYcoordinates(datapoints, group, actualY, previousY) {
     let axis = this._getAxisLeft(group.id);
-    if (group.options.yAxisOrientation == 'right') {
+    if (group.options.yAxisOrientation === 'right') {
       axis = this.yAxisRight;
     }
 
     const offset = 10;
     const baseScreenY = (actualY - previousY) - offset;
-    const listOfValues = datapoints.map(d => d.y)
-      .filter((value, index, self) => self.indexOf(value) === index)
-      .sort();
-
-    if (group.summary && group.group.intervalScale && group.group.minValue !== group.group.maxValue) {
-      if(group.group.maxValue != undefined && !listOfValues.includes(group.group.maxValue)){
-        listOfValues.push(group.group.maxValue);
-      }
-      if(group.group.minValue != undefined && !listOfValues.includes(group.group.minValue)){
-        listOfValues.push(group.group.minValue);
-      }
-    }
-    const range = {
-      max: Math.max(...listOfValues),
-      min: Math.min(...listOfValues)
-    };
+    const range = this._calculateRange(group, datapoints);
 
     for (let i = 0; i < datapoints.length; i++) {
       let convertedValue = 0;
@@ -391,8 +376,8 @@ class TimelineChartLineGraph extends LineGraph {
         convertedValue = Math.round(baseScreenY * 50 / 100);
       } else {
         convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
-        convertedValue = this._convertNegativeScale({ group, range, convertedValue });
       }
+      convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
       datapoints[i].screen_y = (actualY - (offset / 2)) - convertedValue;
     }
     if (range.min === range.max) {
@@ -404,18 +389,13 @@ class TimelineChartLineGraph extends LineGraph {
 
   _convertAvgYcoordinates(datapoints, group, actualY, previousY) {
     let axis = this._getAxisLeft(group.id);
-    if (group.options.yAxisOrientation == 'right') {
+    if (group.options.yAxisOrientation === 'right') {
       axis = this.yAxisRight;
     }
     const offset = 10;
     const baseScreenY = (actualY - previousY) - offset;
-    const listOfMaxValues = datapoints.map(d => d.referenceLine ? d.y : d.maxValue);
-    const listOfMinValues = datapoints.map(d => d.referenceLine ? d.y : d.minValue);
     const baseGraphHeight = (actualY - previousY);
-    const range = {
-      max: group.summary && group.group.maxValue != undefined ? group.group.maxValue : Math.max(...listOfMaxValues),
-      min: group.summary && group.group.minValue != undefined ? group.group.minValue : Math.min(...listOfMinValues)
-    };
+    const range = this._calculateRange(group, datapoints);
 
     for (var i = 0; i < datapoints.length; i++) {
       if (datapoints[i].referenceLine) {
@@ -424,10 +404,10 @@ class TimelineChartLineGraph extends LineGraph {
         const minValue = datapoints[i].y;
         const difference = maxValue - minValue;
         convertedValue = Math.round(baseScreenY * 50 / 100);
-        convertedValue = this._convertNegativeScale({ group, range, convertedValue });
         if(datapoints[i].referenceLine){
           convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
         }
+        convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
         datapoints[i].screen_y = (actualY - (offset / 2)) - convertedValue;
 
         const diffPercent = difference * 100 / (range.max - range.min);
@@ -490,26 +470,65 @@ class TimelineChartLineGraph extends LineGraph {
   /**
    * IF max is less than min so the scale is inverted
    * e.g -4 on top until 4 on bottom
+   * !important: not available for avg coordinates
    * @param group
-   * @param range
    * @param convertedValue
+   * @param baseScreenY
    * @returns {number}
    * @private
    */
-  _convertNegativeScale({ group, range, convertedValue }) {
-    let first = range.max;
-    let last = range.min;
-    if (group?.group?.axisCustomLabel) {
+  _invertScale({ group, convertedValue, baseScreenY }) {
+    if (group.group.axisCustomLabel) {
       const listOfYLabels = group.group.axisCustomLabel.map(d => d.y);
-      first = listOfYLabels[0];
-      last = listOfYLabels[listOfYLabels.length - 1];
-      range.max = Math.max(...listOfYLabels);
-      range.min = Math.min(...listOfYLabels);
-    }
-    if (first < last) {
-      convertedValue = baseScreenY - convertedValue;
+      const first = listOfYLabels[0];
+      const last = listOfYLabels[listOfYLabels.length - 1];
+      if (first < last) {
+        convertedValue = baseScreenY - convertedValue;
+      }
     }
     return convertedValue;
+  }
+
+  _calculateRange(group, datapoints) {
+    if (group.group.axisCustomLabel) {
+      const listOfValues = group.group.axisCustomLabel.map(d => d.y);
+      return {
+        max: Math.max(...listOfValues),
+        min: Math.min(...listOfValues)
+      };
+    }
+    if (group.group.type === 'arrow-avg') {
+      return this._calculateRangeAvg(group, datapoints)
+    }
+    return this._calculateRangePoints(group, datapoints)
+  }
+
+  _calculateRangePoints(group, datapoints) {
+    const listOfValues = datapoints.map(d => d.y)
+      .filter((value, index, self) => self.indexOf(value) === index)
+      .sort();
+
+    if (group.summary && group.group.intervalScale && group.group.minValue !== group.group.maxValue) {
+      if (group.group.maxValue !== undefined && !listOfValues.includes(group.group.maxValue)) {
+        listOfValues.push(group.group.maxValue);
+      }
+      if (group.group.minValue !== undefined && !listOfValues.includes(group.group.minValue)) {
+        listOfValues.push(group.group.minValue);
+      }
+    }
+    return {
+      max: Math.max(...listOfValues),
+      min: Math.min(...listOfValues)
+    };
+  }
+
+  _calculateRangeAvg(group, datapoints) {
+    const listOfMaxValues = datapoints.map(d => d.referenceLine ? d.y : d.maxValue);
+    const listOfMinValues = datapoints.map(d => d.referenceLine ? d.y : d.minValue);
+    return {
+      max: group.summary && group.group.maxValue !== undefined ? group.group.maxValue : Math.max(...listOfMaxValues),
+      min: group.summary && group.group.minValue !== undefined ? group.group.minValue : Math.min(...listOfMinValues)
+    };
   }
 }
 

--- a/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
+++ b/lib/timeline/component/timeline-chart/TimelineChartLineGraph.js
@@ -377,7 +377,9 @@ class TimelineChartLineGraph extends LineGraph {
       } else {
         convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
       }
-      convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
+      if (group.group.axisCustomLabel) {
+        convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
+      }
       datapoints[i].screen_y = (actualY - (offset / 2)) - convertedValue;
     }
     if (range.min === range.max) {
@@ -407,7 +409,9 @@ class TimelineChartLineGraph extends LineGraph {
         if(datapoints[i].referenceLine){
           convertedValue = Math.round(axis.convertValue(datapoints[i].y, range, baseScreenY));
         }
-        convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
+        if (group.group.axisCustomLabel) {
+          convertedValue = this._invertScale({ group, convertedValue, baseScreenY });
+        }
         datapoints[i].screen_y = (actualY - (offset / 2)) - convertedValue;
 
         const diffPercent = difference * 100 / (range.max - range.min);
@@ -478,13 +482,11 @@ class TimelineChartLineGraph extends LineGraph {
    * @private
    */
   _invertScale({ group, convertedValue, baseScreenY }) {
-    if (group.group.axisCustomLabel) {
-      const listOfYLabels = group.group.axisCustomLabel.map(d => d.y);
-      const first = listOfYLabels[0];
-      const last = listOfYLabels[listOfYLabels.length - 1];
-      if (first < last) {
-        convertedValue = baseScreenY - convertedValue;
-      }
+    const listOfYLabels = group.group.axisCustomLabel.map(d => d.y);
+    const first = listOfYLabels[0];
+    const last = listOfYLabels[listOfYLabels.length - 1];
+    if (first < last) {
+      convertedValue = baseScreenY - convertedValue;
     }
     return convertedValue;
   }


### PR DESCRIPTION
- **What feature or fix was requested?**<br/>
Configuração das Legendas “De Lee” e “Hodge”<br/>
 - Criar um campo no backend para setar esses eixos Y específicos.
 - No front cuidar com o posicionamento dos eixos específicos, pois pelas apresentações eles terão posições um pouco diferentes do padrão<br/>

![image](https://user-images.githubusercontent.com/74916274/202765908-1d02fb00-9969-43fc-991c-14b9950ac0f0.png)
 
- **Is there any specific condition to reproduce the scenario?**<br/>

1. Checkout [tasy-backend PARTOGRAM branch](https://github.com/philips-emr/tasy-backend/tree/PARTOGRAM).
a) Configure database to ACUTE_CARE like image below for more data to tests .
2. [tasy-framework-backend](https://github.com/philips-emr/tasy-framework-backend/pull/8114) must be merge before.
3. [visjs ](https://github.com/philips-emr/vis/pull/117) must be merge before.<br/>

![image](https://user-images.githubusercontent.com/74916274/202768176-dee4aee6-eb2e-44c7-98de-63508f5a2e8a.png)

- **Which functions have you tested your implementation?**<br/>
APAP > APAP (registrável) > Atendimento: 990756 > Model: Partogram - masborchardt > Alterar intervalo de 1h para 5 min > Selecionar a data 19/10/2022 a partir das 03:00<br/>

- [ ] Título para cada eixo (agrupado);
![image](https://user-images.githubusercontent.com/74916274/202786557-f585f9e0-f242-46c0-b9e1-ce0ae710c490.png)
- [ ] Padding top e bottom para legenda dos eixos;
- [ ] Alinhamento do eixos Y com a legenda;
![image](https://user-images.githubusercontent.com/74916274/202786745-1ef04e75-09ff-4573-b052-43f72155f4a4.png)
- [ ] Possibilidade de substituir qualquer item da legenda por um texto alternativo;
![image](https://user-images.githubusercontent.com/74916274/202786975-74635d33-d604-4711-bb0a-52caa6c5de26.png)
- [ ] Eixo negativo;
- [ ] Eixo invertido: De Lee mantém os números negativos no topo;
![image](https://user-images.githubusercontent.com/74916274/202787263-943397b5-df1d-47f6-a2c2-03f1e63769b2.png)
- [ ] Caso seja passado para o VIS uma quantidade de labels com altura superior ao eixo, é ocultado um intervalo entre dois números até que caibam na escala;
![LOCAL_INVERT5 - Copy](https://user-images.githubusercontent.com/74916274/202787900-a1c82675-fba9-4a34-9336-08e79eeed813.png)

- **Relevant informations to reviewer?**<br/>
1. [tasy-framework-backend](https://github.com/philips-emr/tasy-framework-backend/pull/8114) must be merge before.
2. [tasy-framework](https://github.com/philips-emr/tasy-framework/pull/24932) PR link.<br/>