### PR TITLE
chore: 🎉 Add this repo as a component to the a developer-portal 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ of the project.
 
 To build the library from source, clone the project from github
 
-    $ git clone git://github.com/almende/vis.git
+    $ git clone git@github.com:philips-emr/vis.git
 
+To keep a default use node 8.15.1 for build.
 The source code uses the module style of node (require and module.exports) to
 organize dependencies. To install all dependencies and build the library, 
 run `npm install` in the root of the project.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+# yamllint disable-file
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "emr-vis"
+  description: "Vis.js is a dynamic, browser based visualization library. The library is designed to be easy to use, handle large amounts of dynamic data, and enable manipulation of the data."
+  title: "vis"
+  tags:
+    - emr
+spec:
+  type: "library"
+  owner: "group:default/emr-tasy-framework-contributors"
+  lifecycle: "production"


### PR DESCRIPTION
This pull request adds a `catalog-info.yaml` file to the root of this repository.
This triggers it to be indexed and added to the [software catalog](https://portal.internal.philips/catalog) in the [developer-portal](https://portal.internal.philips/)

For details, [please take a look at our documentation](https://portal.internal.philips/docs/default/component/developer-portal). And read about [Adding to the catalog](https://portal.internal.philips/docs/default/component/developer-portal/catalog/adding-a-component/)

---
> _This PR is automated by the [Developer Portal](https://portal.internal.philips/)_
